### PR TITLE
feat: fetch and display recent movement logs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,29 @@
         "vitest": "^4.1.5"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2553,7 +2576,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2668,7 +2690,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/frontend/src/pages/Reminder.jsx
+++ b/frontend/src/pages/Reminder.jsx
@@ -4,14 +4,13 @@ function Reminder() {
   const [isMoving, setIsMoving] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [finalDuration, setFinalDuration] = useState(null);
-<<<<<<< HEAD
+
   const [movementLogs, setMovementLogs] = useState([]);
   const [logsLoading, setLogsLoading] = useState(true);
   const [logsError, setLogsError] = useState("");
-=======
+
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
->>>>>>> 3e3306c492600b1d1f3c252f5da9af0e6b035046
 
   const maxSeconds = 10 * 60;
 
@@ -102,10 +101,9 @@ function Reminder() {
   const stopStopwatch = () => {
     setIsMoving(false);
     setFinalDuration(elapsedSeconds);
-<<<<<<< HEAD
+
     saveMovementResponse(elapsedSeconds, "yes");
     fetchMovementLogs();
->>>>>>> 3e3306c492600b1d1f3c252f5da9af0e6b035046
   };
 
   const formatTime = (seconds) => {
@@ -143,7 +141,6 @@ function Reminder() {
         <p>Final duration: {formatTime(finalDuration)}</p>
       )}
 
-<<<<<<< HEAD
       <hr />
 
       <h3>Recent Movement Logs</h3>
@@ -170,11 +167,10 @@ function Reminder() {
             ))}
         </ul>
       )}
-=======
+
       {message && <p>{message}</p>}
 
       {error && <p>{error}</p>}
->>>>>>> 3e3306c492600b1d1f3c252f5da9af0e6b035046
     </section>
   );
 }

--- a/frontend/src/pages/Reminder.jsx
+++ b/frontend/src/pages/Reminder.jsx
@@ -4,8 +4,35 @@ function Reminder() {
   const [isMoving, setIsMoving] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [finalDuration, setFinalDuration] = useState(null);
+  const [movementLogs, setMovementLogs] = useState([]);
+  const [logsLoading, setLogsLoading] = useState(true);
+  const [logsError, setLogsError] = useState("");
 
   const maxSeconds = 10 * 60;
+
+  const fetchMovementLogs = async () => {
+    try {
+      setLogsLoading(true);
+      setLogsError("");
+
+      const response = await fetch("http://localhost:5000/api/movement-log");
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch movement logs");
+      }
+
+      const data = await response.json();
+      setMovementLogs(data);
+    } catch (error) {
+      setLogsError(error.message);
+    } finally {
+      setLogsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMovementLogs();
+  }, []);
 
   useEffect(() => {
     if (!isMoving) {
@@ -36,6 +63,7 @@ function Reminder() {
   const stopStopwatch = () => {
     setIsMoving(false);
     setFinalDuration(elapsedSeconds);
+    fetchMovementLogs();
   };
 
   const formatTime = (seconds) => {
@@ -64,6 +92,33 @@ function Reminder() {
 
       {finalDuration !== null && (
         <p>Final duration: {formatTime(finalDuration)}</p>
+      )}
+
+      <hr />
+
+      <h3>Recent Movement Logs</h3>
+      <button onClick={fetchMovementLogs}>Refresh logs</button>
+
+      {logsLoading && <p>Loading movement logs...</p>}
+
+      {logsError && <p>{logsError}</p>}
+
+      {!logsLoading && !logsError && movementLogs.length === 0 && (
+        <p>No movement logs found.</p>
+      )}
+
+      {!logsLoading && !logsError && movementLogs.length > 0 && (
+        <ul>
+          {movementLogs
+            .filter((log) => log.moved)
+            .map((log) => (
+              <li key={log._id}>
+                <strong>Moved:</strong> {log.moved ? "Yes" : "No"} |{" "}
+                <strong>Duration:</strong> {formatTime(log.durationSeconds)} |{" "}
+                <strong>Points:</strong> {log.pointsEarned}
+              </li>
+            ))}
+        </ul>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

Implemented frontend functionality to fetch and display recent movement logs from the backend API.

---

## Features Added

* Fetch movement logs from backend
* Display recent movement responses on the Reminder page
* Show whether the user moved
* Show movement duration
* Show points earned
* Refresh logs after movement response
* Added loading and error handling

---

## Notes

* Filtered logs to only display valid movement entries
* Connected frontend Reminder page to MongoDB backend data
