### PR TITLE
feat: create signup page

### DIFF
--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -1,16 +1,83 @@
+import { useState } from "react";
+
 function SignUp() {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSignUp = async () => {
+    setMessage("");
+    setError("");
+
+    try {
+      const response = await fetch("http://localhost:5000/api/auth/signup", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username,
+          email,
+          password,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Signup failed");
+      }
+
+      setMessage("Account created successfully.");
+      setUsername("");
+      setEmail("");
+      setPassword("");
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
   return (
     <section>
       <h2>Sign Up</h2>
 
-      <input type="text" placeholder="Username" />
-      <br />
-      <br />
-      <input type="password" placeholder="Password" />
+      <input
+        type="text"
+        placeholder="Username"
+        value={username}
+        onChange={(event) => setUsername(event.target.value)}
+      />
+
       <br />
       <br />
 
-      <button>Create Account</button>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+      />
+
+      <br />
+      <br />
+
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(event) => setPassword(event.target.value)}
+      />
+
+      <br />
+      <br />
+
+      <button onClick={handleSignUp}>Create Account</button>
+
+      {message && <p>{message}</p>}
+      {error && <p>{error}</p>}
     </section>
   );
 }


### PR DESCRIPTION
Implemented frontend signup page connected to backend auth signup route.

Features added:
- Username, email, and password inputs
- Form submission to /api/auth/signup
- Success feedback after account creation
- Error handling for failed signup requests
- Clears form after successful signup
- Connected signup page to app navigation