### PR TITLE
feat: create leaderboard page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Reminder from "./pages/Reminder.jsx";
 import SignUp from "./pages/SignUp.jsx";
 import Dashboard from "./pages/Dashboard.jsx";
 import Account from "./pages/Account.jsx";
+import Leaderboard from "./pages/Leaderboard.jsx";
 
 function App() {
   const [currentPage, setCurrentPage] = useState("home");
@@ -20,7 +21,9 @@ function App() {
               <button onClick={() => setCurrentPage("home")}>Home</button>
             </li>
             <li>
-              <button>Leaderboard</button>
+              <button onClick={() => setCurrentPage("leaderboard")}>
+                Leaderboard
+              </button>
             </li>
             <li>
               <button onClick={() => setCurrentPage("account")}>Account</button>
@@ -52,6 +55,7 @@ function App() {
         {currentPage === "signup" && <SignUp />}
         {currentPage === "dashboard" && <Dashboard />}
         {currentPage === "account" && <Account />}
+        {currentPage === "leaderboard" && <Leaderboard />}
       </main>
     </div>
   );

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+function Leaderboard() {
+  const [users, setUsers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchLeaderboard = async () => {
+      try {
+        setIsLoading(true);
+        setError("");
+
+        const response = await fetch(
+          "http://localhost:5000/api/users/leaderboard"
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch leaderboard");
+        }
+
+        const data = await response.json();
+        setUsers(data);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchLeaderboard();
+  }, []);
+
+  return (
+    <section>
+      <h2>Leaderboard</h2>
+
+      {isLoading && <p>Loading leaderboard...</p>}
+
+      {error && <p>{error}</p>}
+
+      {!isLoading && !error && users.length === 0 && (
+        <p>No leaderboard users found.</p>
+      )}
+
+      {!isLoading && !error && users.length > 0 && (
+        <ol>
+          {users.map((user) => (
+            <li key={user._id}>
+              <strong>{user.username}</strong> — {user.totalPoints} points
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+export default Leaderboard;


### PR DESCRIPTION
## What I changed

- Created a new `Leaderboard.jsx` page
- Added leaderboard navigation button in `App.jsx`
- Connected frontend to backend leaderboard API route
- Displayed users sorted by total points
- Added loading and error handling states

## Features

- Fetches leaderboard data from:
  `/api/users/leaderboard`
- Displays username and total points
- Shows ranked users in ordered list format
- Handles empty leaderboard state gracefully

## Notes

- Uses backend leaderboard route instead of calculating rankings on frontend
- Keeps implementation simple for checkpoint requirements