### PR TITLE
feat: add reminder response timeout

### DIFF
--- a/frontend/src/pages/Reminder.jsx
+++ b/frontend/src/pages/Reminder.jsx
@@ -62,6 +62,29 @@ function Reminder({ onClose, onMovementSaved }) {
     return () => clearInterval(timer);
   }, [isMoving]);
 
+  useEffect(() => {
+    if (!onClose) {
+      return;
+    }
+
+    const timeout = setTimeout(
+      async () => {
+        await saveMovementResponse(0, "timeout");
+
+        await fetchMovementLogs();
+
+        if (onMovementSaved) {
+          onMovementSaved();
+        }
+
+        onClose();
+      },
+      5 * 60 * 1000
+    );
+
+    return () => clearTimeout(timeout);
+  }, [onClose]);
+
   const saveMovementResponse = async (durationSeconds, responseType) => {
     setMessage("");
     setError("");


### PR DESCRIPTION
## Features

- Timeout starts when modal opens
- Timeout stops after user answers
- Timeout saves movement response with responseType "timeout"
- Timeout counts as missed reminder

## Notes

- Uses existing movement response flow
- Keeps timeout cleanup with clearTimeout