### PR TITLE
fix: configure production cors settings and formatted

### DIFF
--- a/backend/.env.exmaple
+++ b/backend/.env.exmaple
@@ -1,3 +1,4 @@
 PORT=5000
 MONGO_URI=your_real_mongodb_connection_string
 JWT_SECRET=replace_this_with_a_long_random_secret
+FRONTEND_URL=http://localhost:5173

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,7 +8,23 @@ const authRoutes = require("./routes/authRoutes");
 
 const app = express();
 
-app.use(cors());
+const allowedOrigins = [
+  "http://localhost:5173",
+  process.env.CLIENT_URL,
+  process.env.FRONTEND_URL,
+].filter(Boolean);
+
+const corsOptions = {
+  origin(origin, callback) {
+    if (!origin || allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+
+    return callback(null, false);
+  },
+};
+
+app.use(cors(corsOptions));
 app.use(express.json());
 
 app.use("/api/health", healthRoutes);

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,8 +1,9 @@
 const dotenv = require("dotenv");
-const app = require("./app");
-const connectDB = require("./config/db");
 
 dotenv.config();
+
+const app = require("./app");
+const connectDB = require("./config/db");
 
 const PORT = process.env.PORT || 5000;
 


### PR DESCRIPTION
- Configures backend CORS to allow the local frontend and deployed frontend URL from environment variables
- Stops allowing every origin by default
- Loads dotenv before the Express app so CORS environment variables are available
- Tested local frontend origin with curl
- Tested random origin does not receive CORS allow header
- Confirmed health endpoint still works