### PR TITLE
feat: added delete account route

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -125,10 +125,39 @@ const updateUserSettings = async (req, res) => {
   }
 };
 
+const deleteUserAccount = async (req, res) => {
+  try {
+    const userId = req.params.userId;
+
+    if (req.userId !== userId) {
+      return res.status(403).json({
+        error: "You can only delete your own account",
+      });
+    }
+
+    const deletedUser = await User.findByIdAndDelete(userId);
+
+    if (!deletedUser) {
+      return res.status(404).json({
+        error: "User not found",
+      });
+    }
+
+    return res.status(200).json({
+      message: "User account deleted",
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: "Failed to delete user account",
+    });
+  }
+};
+
 module.exports = {
   getUserSummary,
   getLeaderboard,
   getUserSettings,
   updateUserSettings,
   getUserStats,
+  deleteUserAccount,
 };

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -7,6 +7,7 @@ const {
   getUserSettings,
   updateUserSettings,
   getUserStats,
+  deleteUserAccount,
 } = require("../controllers/userController");
 
 const requireAuth = require("../middleware/authMiddleware");
@@ -22,6 +23,7 @@ router.get("/me/settings", requireAuth, getUserSettings);
 router.patch("/me/settings", requireAuth, updateUserSettings);
 
 router.get("/leaderboard", getLeaderboard);
+router.delete("/:userId", requireAuth, deleteUserAccount);
 router.get("/:userId/summary", getUserSummary);
 router.get("/:userId/stats", getUserStats);
 


### PR DESCRIPTION
Added a protected DELETE route for deleting a user account that deletes the user by id from MongoDB and added a safety check so users can only delete their own account

closes #145 