### PR TITLE
refactor: remove reminder page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,6 @@ import {
 } from "@mui/material";
 import Home from "./pages/Home.jsx";
 import About from "./pages/About.jsx";
-import Reminder from "./pages/Reminder.jsx";
 import SignUp from "./pages/SignUp.jsx";
 import Dashboard from "./pages/Dashboard.jsx";
 import { useAuth } from "./context/AuthContext.jsx";
@@ -51,8 +50,6 @@ function App() {
 
             <Button onClick={() => setCurrentPage("about")}>About</Button>
 
-            <Button onClick={() => setCurrentPage("reminder")}>Reminder</Button>
-
             {isLoggedIn && (
               <>
                 <Button onClick={() => setCurrentPage("dashboard")}>
@@ -88,7 +85,6 @@ function App() {
       <Container component="main" maxWidth="lg" sx={{ py: 4, flex: 1 }}>
         {currentPage === "home" && <Home setCurrentPage={setCurrentPage} />}
         {currentPage === "about" && <About />}
-        {currentPage === "reminder" && <Reminder />}
         {currentPage === "signup" && <SignUp />}
 
         {currentPage === "dashboard" && (

--- a/frontend/src/components/dashboard/ReminderContent.jsx
+++ b/frontend/src/components/dashboard/ReminderContent.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import API_BASE_URL from "../config/api.js";
-import { useAuth } from "../context/AuthContext.jsx";
+import API_BASE_URL from "../../config/api.js";
+import { useAuth } from "../../context/AuthContext.jsx";
 
-function Reminder({ onClose, onMovementSaved }) {
+function ReminderContent({ onClose, onMovementSaved }) {
   const { user, token } = useAuth();
   const userId = user?.id || user?._id;
 
@@ -10,42 +10,10 @@ function Reminder({ onClose, onMovementSaved }) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [finalDuration, setFinalDuration] = useState(null);
 
-  const [movementLogs, setMovementLogs] = useState([]);
-  const [logsLoading, setLogsLoading] = useState(true);
-  const [logsError, setLogsError] = useState("");
-
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
 
   const maxSeconds = 10 * 60;
-
-  const fetchMovementLogs = async () => {
-    try {
-      setLogsLoading(true);
-      setLogsError("");
-
-      const response = await fetch(`${API_BASE_URL}/api/movement-logs/me`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to fetch movement logs");
-      }
-
-      const data = await response.json();
-      setMovementLogs(data);
-    } catch (error) {
-      setLogsError(error.message);
-    } finally {
-      setLogsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchMovementLogs();
-  }, []);
 
   useEffect(() => {
     if (!isMoving) {
@@ -75,8 +43,6 @@ function Reminder({ onClose, onMovementSaved }) {
     const timeout = setTimeout(
       async () => {
         await saveMovementResponse(0, "timeout");
-
-        await fetchMovementLogs();
 
         if (onMovementSaved) {
           onMovementSaved();
@@ -142,7 +108,6 @@ function Reminder({ onClose, onMovementSaved }) {
     setFinalDuration(0);
 
     await saveMovementResponse(0, "no");
-    await fetchMovementLogs();
 
     if (onClose) {
       onClose();
@@ -154,7 +119,6 @@ function Reminder({ onClose, onMovementSaved }) {
     setFinalDuration(elapsedSeconds);
 
     await saveMovementResponse(elapsedSeconds, "yes");
-    fetchMovementLogs();
   };
 
   const formatTime = (seconds) => {
@@ -206,33 +170,6 @@ function Reminder({ onClose, onMovementSaved }) {
         <p>Final duration: {formatTime(finalDuration)}</p>
       )}
 
-      <hr />
-
-      <h3>Recent Movement Logs</h3>
-      <button onClick={fetchMovementLogs}>Refresh logs</button>
-
-      {logsLoading && <p>Loading movement logs...</p>}
-
-      {logsError && <p>{logsError}</p>}
-
-      {!logsLoading && !logsError && movementLogs.length === 0 && (
-        <p>No movement logs found.</p>
-      )}
-
-      {!logsLoading && !logsError && movementLogs.length > 0 && (
-        <ul>
-          {movementLogs.map((log) => (
-            <li key={log._id}>
-              <strong>Moved:</strong> {log.moved ? "Yes" : "No"} |{" "}
-              <strong>Duration:</strong> {formatTime(log.durationSeconds)} |{" "}
-              <strong>Points:</strong> {log.pointsEarned} |{" "}
-              <strong>Created:</strong>{" "}
-              {new Date(log.createdAt).toLocaleString()}
-            </li>
-          ))}
-        </ul>
-      )}
-
       {message && <p>{message}</p>}
 
       {error && <p>{error}</p>}
@@ -240,4 +177,4 @@ function Reminder({ onClose, onMovementSaved }) {
   );
 }
 
-export default Reminder;
+export default ReminderContent;

--- a/frontend/src/components/dashboard/ReminderModal.jsx
+++ b/frontend/src/components/dashboard/ReminderModal.jsx
@@ -1,4 +1,4 @@
-import Reminder from "../../pages/Reminder.jsx";
+import ReminderContent from "./ReminderContent.jsx";
 
 function ReminderModal({ onClose, onMovementSaved }) {
   return (
@@ -21,7 +21,7 @@ function ReminderModal({ onClose, onMovementSaved }) {
           textAlign: "center",
         }}
       >
-        <Reminder onClose={onClose} onMovementSaved={onMovementSaved} />
+        <ReminderContent onClose={onClose} onMovementSaved={onMovementSaved} />
       </div>
     </div>
   );

--- a/frontend/src/pages/Account.jsx
+++ b/frontend/src/pages/Account.jsx
@@ -12,11 +12,16 @@ function Account() {
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
+  const [movementLogs, setMovementLogs] = useState([]);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const [logsError, setLogsError] = useState("");
 
   useEffect(() => {
     const fetchAccount = async () => {
       try {
         setIsLoading(true);
+        setLogsLoading(true);
+        setLogsError("");
         setErrorMessage("");
 
         const response = await fetch(`${API_BASE_URL}/api/users/me/settings`, {
@@ -34,10 +39,27 @@ function Account() {
         setUser(authUser);
         setReminderMode(data.reminderMode || "science");
         setCustomReminderMinutes(data.customReminderMinutes || "");
+        const logsResponse = await fetch(
+          `${API_BASE_URL}/api/movement-logs/me`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+
+        if (!logsResponse.ok) {
+          throw new Error("Failed to load movement logs");
+        }
+
+        const logsData = await logsResponse.json();
+        setMovementLogs(logsData.slice(0, 3));
       } catch (error) {
         setErrorMessage("Could not load account information.");
+        setLogsError("Could not load recent movement logs.");
       } finally {
         setIsLoading(false);
+        setLogsLoading(false);
       }
     };
 
@@ -48,6 +70,12 @@ function Account() {
       setErrorMessage("You need to be logged in to view this page.");
     }
   }, [token, authUser]);
+
+  const formatTime = (seconds = 0) => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+  };
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -122,6 +150,28 @@ function Account() {
         <p>Total points: {user.totalPoints ?? 0}</p>
         <p>Current session streak: {user.currentSessionStreak ?? 0}</p>
         <p>Best session streak: {user.bestSessionStreak ?? 0}</p>
+        <h3>Recent Movement Logs</h3>
+
+        {logsLoading && <p>Loading recent movement logs...</p>}
+
+        {logsError && <p>{logsError}</p>}
+
+        {!logsLoading && !logsError && movementLogs.length === 0 && (
+          <p>No recent movement logs found.</p>
+        )}
+
+        {!logsLoading && !logsError && movementLogs.length > 0 && (
+          <ul>
+            {movementLogs.map((log) => (
+              <li key={log._id}>
+                Response: {log.responseType || (log.moved ? "yes" : "no")} |
+                Duration: {formatTime(log.durationSeconds)} | Points:{" "}
+                {log.pointsEarned} | Created:{" "}
+                {new Date(log.createdAt).toLocaleString()}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
 
       <form onSubmit={handleSubmit}>


### PR DESCRIPTION
Removed the standalone Reminder page from navigation/rendering
Kept reminder functionality available through the dashboard modal
moved recent movement logs to the Account page and limited them to the 3 most recent logs

Reminder page no longer appears in the navbar
dashboard reminder modal still opens
Yes/No movement responses still save
Account page shows recent movement logs

closes #140 