### PR TITLE
fix: apply saved reminder settings among other fixes 

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -70,10 +70,10 @@ function App() {
             direction="row"
             spacing={{ xs: 0.5, sm: 1 }}
             useFlexGap
-            flexWrap="wrap"
-            justifyContent={{ xs: "center", md: "flex-end" }}
             sx={{
               width: { xs: "100%", md: "auto" },
+              flexWrap: "wrap",
+              justifyContent: { xs: "center", md: "flex-end" },
               rowGap: 1,
             }}
           >

--- a/frontend/src/pages/Account.jsx
+++ b/frontend/src/pages/Account.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../context/AuthContext.jsx";
 
 function Account() {
   const { user: authUser, token } = useAuth();
+  const userId = authUser?.id || authUser?._id;
 
   const [user, setUser] = useState(null);
   const [reminderMode, setReminderMode] = useState("science");
@@ -36,7 +37,25 @@ function Account() {
 
         const data = await response.json();
 
-        setUser(authUser);
+        const statsResponse = await fetch(
+          `${API_BASE_URL}/api/users/me/stats`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+
+        if (!statsResponse.ok) {
+          throw new Error("Failed to load user stats");
+        }
+
+        const statsData = await statsResponse.json();
+
+        setUser({
+          ...authUser,
+          ...(statsData.user || {}),
+        });
         setReminderMode(data.reminderMode || "science");
         setCustomReminderMinutes(data.customReminderMinutes || "");
         const logsResponse = await fetch(
@@ -63,13 +82,13 @@ function Account() {
       }
     };
 
-    if (token && authUser) {
+    if (token && authUser && userId) {
       fetchAccount();
     } else {
       setIsLoading(false);
       setErrorMessage("You need to be logged in to view this page.");
     }
-  }, [token, authUser]);
+  }, [token, authUser, userId]);
 
   const formatTime = (seconds = 0) => {
     const minutes = Math.floor(seconds / 60);

--- a/frontend/src/pages/Account.jsx
+++ b/frontend/src/pages/Account.jsx
@@ -212,7 +212,7 @@ function Account() {
               id="customReminderMinutes"
               type="number"
               min="1"
-              max="15"
+              max="60"
               value={customReminderMinutes}
               onChange={(event) => setCustomReminderMinutes(event.target.value)}
             />

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -5,13 +5,18 @@ import ScoreStreakSummary from "../components/dashboard/ScoreStreakSummary.jsx";
 import API_BASE_URL from "../config/api.js";
 import { useAuth } from "../context/AuthContext.jsx";
 
-const reminderIntervalSeconds = 10;
+const defaultReminderIntervalSeconds = 10;
 
 function Dashboard() {
   const { user, token } = useAuth();
   const userId = user?.id || user?._id;
 
-  const [secondsLeft, setSecondsLeft] = useState(reminderIntervalSeconds);
+  const [reminderIntervalSeconds, setReminderIntervalSeconds] = useState(
+    defaultReminderIntervalSeconds
+  );
+  const [secondsLeft, setSecondsLeft] = useState(
+    defaultReminderIntervalSeconds
+  );
   const [isTimerRunning, setIsTimerRunning] = useState(false);
   const [isReminderModalOpen, setIsReminderModalOpen] = useState(false);
 
@@ -21,6 +26,39 @@ function Dashboard() {
   const [userStats, setUserStats] = useState(null);
   const [statsLoading, setStatsLoading] = useState(false);
   const [statsError, setStatsError] = useState("");
+
+  const fetchReminderSettings = async () => {
+    if (!token) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/users/me/settings`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch reminder settings");
+      }
+
+      const data = await response.json();
+
+      if (data.reminderMode === "custom" && data.customReminderMinutes) {
+        const customSeconds = Number(data.customReminderMinutes) * 60;
+        setReminderIntervalSeconds(customSeconds);
+        setSecondsLeft(customSeconds);
+        return;
+      }
+
+      setReminderIntervalSeconds(defaultReminderIntervalSeconds);
+      setSecondsLeft(defaultReminderIntervalSeconds);
+    } catch (error) {
+      setReminderIntervalSeconds(defaultReminderIntervalSeconds);
+      setSecondsLeft(defaultReminderIntervalSeconds);
+    }
+  };
 
   const fetchMovementLogs = async () => {
     if (!userId) {
@@ -55,14 +93,11 @@ function Dashboard() {
       setStatsLoading(true);
       setStatsError("");
 
-      const response = await fetch(
-        `${API_BASE_URL}/api/users/${userId}/stats`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
+      const response = await fetch(`${API_BASE_URL}/api/users/me/stats`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
 
       if (!response.ok) {
         throw new Error("Failed to fetch user stats");
@@ -78,17 +113,18 @@ function Dashboard() {
   };
 
   const refreshDashboardData = async () => {
+    await fetchReminderSettings();
     await fetchUserStats();
     await fetchMovementLogs();
   };
 
   useEffect(() => {
-    if (!userId) {
+    if (!userId || !token) {
       return;
     }
 
     refreshDashboardData();
-  }, [userId]);
+  }, [userId, token]);
 
   useEffect(() => {
     if (!isTimerRunning || secondsLeft <= 0) {

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -77,14 +77,14 @@ function Leaderboard() {
                     px: 2,
                   }}
                 >
-                <ListItemText
-                  primary={
-                    <Typography component="span" fontWeight="bold">
-                      #{index + 1} {user.username}
-                    </Typography>
-                  }
-                  secondary={`${user.totalPoints} points`}
-                />
+                  <ListItemText
+                    primary={
+                      <Typography component="span" fontWeight="bold">
+                        #{index + 1} {user.username}
+                      </Typography>
+                    }
+                    secondary={`${user.totalPoints} points`}
+                  />
                 </ListItem>
               ))}
             </List>

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -77,13 +77,14 @@ function Leaderboard() {
                     px: 2,
                   }}
                 >
-                  <ListItemText
-                    primary={`#${index + 1} ${user.username}`}
-                    secondary={`${user.totalPoints} points`}
-                    primaryTypographyProps={{
-                      fontWeight: "bold",
-                    }}
-                  />
+                <ListItemText
+                  primary={
+                    <Typography component="span" fontWeight="bold">
+                      #{index + 1} {user.username}
+                    </Typography>
+                  }
+                  secondary={`${user.totalPoints} points`}
+                />
                 </ListItem>
               ))}
             </List>


### PR DESCRIPTION
Fixed the custom reminder flow so the Account setting actually affects the Dashboard timer. Also fixed Account/Dashboard stats loading with the logged-in stats endpoint and cleaned up a couple console warnings found while testing.

Tested locally by saving a custom reminder, checking the Dashboard timer, confirming stats update after movement, and checking the console.

Closes #194