### PR TITLE
feat: add admin movement log update route

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ const healthRoutes = require("./routes/healthRoutes");
 const movementLogRoutes = require("./routes/movementLogRoutes");
 const userRoutes = require("./routes/userRoutes");
 const authRoutes = require("./routes/authRoutes");
+const adminRoutes = require("./routes/adminRoutes");
 
 const app = express();
 
@@ -41,6 +42,7 @@ app.use("/api/health", healthRoutes);
 app.use("/api/movement-logs", movementLogRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/auth", authRoutes);
+app.use("/api/admin", adminRoutes);
 
 app.get("/", (req, res) => {
   res.json({ message: "moveUp backend is running" });

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,0 +1,106 @@
+const MovementLog = require("../models/MovementLog");
+
+const allowedUpdateFields = [
+  "responseType",
+  "durationSeconds",
+  "creditedSeconds",
+  "pointsEarned",
+];
+
+const updateMovementLog = async (req, res) => {
+  try {
+    const updates = {};
+
+    for (const field of allowedUpdateFields) {
+      if (req.body[field] !== undefined) {
+        updates[field] = req.body[field];
+      }
+    }
+
+    const hasUpdates = Object.keys(updates).length > 0;
+
+    if (!hasUpdates) {
+      return res.status(400).json({
+        error: "No valid update fields provided",
+      });
+    }
+
+    if (
+      updates.responseType !== undefined &&
+      !["yes", "no", "timeout"].includes(updates.responseType)
+    ) {
+      return res.status(400).json({
+        error: "Invalid responseType",
+      });
+    }
+
+    if (
+      updates.durationSeconds !== undefined &&
+      (typeof updates.durationSeconds !== "number" ||
+        updates.durationSeconds < 0)
+    ) {
+      return res.status(400).json({
+        error: "durationSeconds must be 0 or higher",
+      });
+    }
+
+    if (
+      updates.creditedSeconds !== undefined &&
+      (typeof updates.creditedSeconds !== "number" ||
+        updates.creditedSeconds < 0 ||
+        updates.creditedSeconds > 600)
+    ) {
+      return res.status(400).json({
+        error: "creditedSeconds must be between 0 and 600",
+      });
+    }
+
+    if (
+      updates.pointsEarned !== undefined &&
+      (typeof updates.pointsEarned !== "number" || updates.pointsEarned < 0)
+    ) {
+      return res.status(400).json({
+        error: "pointsEarned must be 0 or higher",
+      });
+    }
+
+    if (updates.responseType === "no" || updates.responseType === "timeout") {
+      updates.moved = false;
+      updates.durationSeconds = 0;
+      updates.creditedSeconds = 0;
+      updates.pointsEarned = 0;
+    }
+
+    if (updates.responseType === "yes") {
+      updates.moved = true;
+    }
+
+    const updatedLog = await MovementLog.findByIdAndUpdate(
+      req.params.id,
+      updates,
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
+
+    if (!updatedLog) {
+      return res.status(404).json({
+        error: "Movement log not found",
+      });
+    }
+
+    return res.status(200).json({
+      message: "Movement log updated",
+      movementLog: updatedLog,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: "Failed to update movement log",
+    });
+  }
+};
+
+module.exports = {
+  updateMovementLog,
+};

--- a/backend/src/middleware/adminMiddleware.js
+++ b/backend/src/middleware/adminMiddleware.js
@@ -1,0 +1,21 @@
+const User = require("../models/User");
+
+const requireAdmin = async (req, res, next) => {
+  try {
+    const user = await User.findById(req.userId).select("isAdmin");
+
+    if (!user || !user.isAdmin) {
+      return res.status(403).json({
+        error: "Admin access required",
+      });
+    }
+
+    return next();
+  } catch (error) {
+    return res.status(500).json({
+      error: "Failed to verify admin access",
+    });
+  }
+};
+
+module.exports = requireAdmin;

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -68,6 +68,11 @@ const userSchema = new mongoose.Schema(
       default: null,
     },
 
+    isAdmin: {
+      type: Boolean,
+      default: false,
+    },
+
     lastDailyBonusDate: {
       type: Date,
       default: null,

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const requireAuth = require("../middleware/authMiddleware");
+const requireAdmin = require("../middleware/adminMiddleware");
+const { updateMovementLog } = require("../controllers/adminController");
+
+const router = express.Router();
+
+router.patch(
+  "/movement-logs/:id",
+  requireAuth,
+  requireAdmin,
+  updateMovementLog
+);
+
+module.exports = router;


### PR DESCRIPTION
Added an admin-only route for updating movement logs. It checks that the user is logged in and has admin access, only allows safe fields to be edited, and returns the updated log.

Tested locally with an admin user and invalid update values.

Closes #188